### PR TITLE
Fixes modal ID bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
-Here you can find a list of changes to the Dry Rock project as well as up coming
+Here you can find a list of changes to the Dry Rock project as well as upcoming
 features.
 
-## Unreleased
+## [2.1.1] - 2024-11-01
+
+### Fixed
+
+- Bug causing daily detailed modals to break Lower Cove location
 
 ## [2.1.0] - 2024-11-01
 

--- a/dryrock/reports/templates/forecast_table.html.j2
+++ b/dryrock/reports/templates/forecast_table.html.j2
@@ -1,5 +1,3 @@
-
-
 <div class="table-responsive">
   <table class="table table-hover border-bottom">
     <thead>
@@ -14,128 +12,132 @@
     </thead>
     <tbody>
       {% for day in days %}
-        {% with forecast = forecasts[day] %}
-          <tr style="transform: rotate(0);" {% if day.weekday() in [5, 6] %} class="font-weight-bolder" {% endif %}>
-            <th scope="row" class="position-sticky bg-white" style="left: 0">
-              <a href="#{{ place.name.replace(' ', '') }}{{ day }}" data-toggle="modal" class="stretched-link"></a>
-              <div class="text-nowrap d-inline">
-                {{ day.strftime("%a") }} <small class="text-muted d-none d-md-inline">{{ day.strftime("%d %b") }}</small>
-              </div>
-            </th>
+      {% with forecast = forecasts[day] %}
+      <tr style="transform: rotate(0);" {% if day.weekday() in [5, 6] %} class="font-weight-bolder" {% endif %}>
+        <th scope="row" class="position-sticky bg-white" style="left: 0">
+          {# Remove characters from name that break the modal toggle #}
+          <a href="#{{ place.name.replace(' ', '').replace('(', '').replace(')', '') }}{{ day }}" data-toggle="modal"
+            class="stretched-link"></a>
+          <div class="text-nowrap d-inline">
+            {{ day.strftime("%a") }} <small class="text-muted d-none d-md-inline">{{ day.strftime("%d %b") }}</small>
+          </div>
+        </th>
 
-            {% if forecast.morning_rain %}
-              {% if forecast.morning_rain.value <= 1.0 %}
-                <td class="text-success text-nowrap">
-              {% else %}
-                <td class="text-primary text-nowrap">
-              {% endif %}
-                {{ forecast.morning_rain.value | round(1) }} {{ forecast.morning_rain.units }}
-              </td>
-            {% else %}
-              <td></td>
+        {% if forecast.morning_rain %}
+        {% if forecast.morning_rain.value <= 1.0 %} <td class="text-success text-nowrap">
+          {% else %}
+          <td class="text-primary text-nowrap">
             {% endif %}
+            {{ forecast.morning_rain.value | round(1) }} {{ forecast.morning_rain.units }}
+          </td>
+          {% else %}
+          <td></td>
+          {% endif %}
 
-            {% if forecast.afternoon_rain %}
-              {% if forecast.afternoon_rain.value <= 1.0 %}
-                <td class="text-success text-nowrap">
-              {% else %}
-                <td class="text-primary text-nowrap">
-              {% endif %}
-                {{ forecast.afternoon_rain.value | round(1) }} {{ forecast.afternoon_rain.units }}
-              </td>
+          {% if forecast.afternoon_rain %}
+          {% if forecast.afternoon_rain.value <= 1.0 %} <td class="text-success text-nowrap">
             {% else %}
-              <td></td>
+            <td class="text-primary text-nowrap">
+              {% endif %}
+              {{ forecast.afternoon_rain.value | round(1) }} {{ forecast.afternoon_rain.units }}
+            </td>
+            {% else %}
+            <td></td>
             {% endif %}
 
             {% if forecast.evening_rain %}
-              {% if forecast.evening_rain.value <= 1.0 %}
-                <td class="text-success text-nowrap">
+            {% if forecast.evening_rain.value <= 1.0 %} <td class="text-success text-nowrap">
               {% else %}
-                <td class="text-primary text-nowrap">
-              {% endif %}
+              <td class="text-primary text-nowrap">
+                {% endif %}
                 {{ forecast.evening_rain.value | round(1) }} {{ forecast.evening_rain.units }}
               </td>
-            {% else %}
-              <td></td>
-            {% endif %}
-
-            <td class="text-danger text-nowrap">
-              {{forecast.min_temp.value | round | int }} / {{ forecast.max_temp.value | round | int }}
-              {% if forecast.max_temp.units == "celsius" %}
-                &deg;C
-              {% elif forecast.max_temp.units == "farenheit" %}
-                &deg;F
               {% else %}
-                forecast.max_temp.units
+              <td></td>
               {% endif %}
-            </td>
-            <td class="text-nowrap">
-              <a href="#{{ place.name.replace(' ', '') }}{{ day }}" data-toggle="modal" class="stretched-link"></a>
-              {{ forecast.max_wind_speed.value | round | int }} {{ forecast.max_wind_speed.units }} {{ forecast.max_wind_speed_direction }}
-            </td>
-          </tr>
-        {% endwith %}
+
+              <td class="text-danger text-nowrap">
+                {{forecast.min_temp.value | round | int }} / {{ forecast.max_temp.value | round | int }}
+                {% if forecast.max_temp.units == "celsius" %}
+                &deg;C
+                {% elif forecast.max_temp.units == "farenheit" %}
+                &deg;F
+                {% else %}
+                forecast.max_temp.units
+                {% endif %}
+              </td>
+              <td class="text-nowrap">
+                {# Remove characters from name that break the modal toggle #}
+                <a href="#{{ place.name.replace(' ', '').replace('(', '').replace(')', '') }}{{ day }}"
+                  data-toggle="modal" class="stretched-link"></a>
+                {{ forecast.max_wind_speed.value | round | int }} {{ forecast.max_wind_speed.units }} {{
+                forecast.max_wind_speed_direction }}
+              </td>
+      </tr>
+      {% endwith %}
       {% endfor %}
     </tbody>
   </table>
 </div>
 
 {% for day in days %}
-  <div class="modal fade" id="{{ place.name.replace(' ', '') }}{{ day }}" tabindex="-1" aria-labelledby="{{ place.name }}{{ day }}Label" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="{{ place.name }}{{ day }}Label">{{ place.name }}</h5>
-          <h5 class="modal-title ml-auto">{{ day.strftime("%a") }} <small class="text-muted">{{ day.strftime("%d %b") }}</small></h5>
-          <button type="button" class="close ml-0" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          <table class="table">
-            <thead>
-              <tr>
-                <th scope="col">Time</th>
-                <th scope="col">Rain</th>
-                <th scope="col">Temp.</th>
-                <th scope="col">Wind</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for interval in forecasts[day].intervals %}
-                <tr>
-                  <td class="text-nowrap">
-                    {{ interval.start_time.strftime("%H")}} - {{ interval.end_time.strftime("%H")}}
-                  </td>
+{# Remove characters from name that break the modal toggle #}
+<div class="modal fade" id="{{ place.name.replace(' ', '').replace('(', '').replace(')', '') }}{{ day }}" tabindex="-1"
+  aria-labelledby="{{ place.name }}{{ day }}Label" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-scrollable modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="{{ place.name }}{{ day }}Label">{{ place.name }}</h5>
+        <h5 class="modal-title ml-auto">{{ day.strftime("%a") }} <small class="text-muted">{{ day.strftime("%d %b")
+            }}</small></h5>
+        <button type="button" class="close ml-0" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <table class="table">
+          <thead>
+            <tr>
+              <th scope="col">Time</th>
+              <th scope="col">Rain</th>
+              <th scope="col">Temp.</th>
+              <th scope="col">Wind</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for interval in forecasts[day].intervals %}
+            <tr>
+              <td class="text-nowrap">
+                {{ interval.start_time.strftime("%H")}} - {{ interval.end_time.strftime("%H")}}
+              </td>
 
-                  {% if interval.rain.value <= 0.5 %}
-                    <td class="text-success text-nowrap">
-                  {% else %}
-                    <td class="text-primary text-nowrap">
+              {% if interval.rain.value <= 0.5 %} <td class="text-success text-nowrap">
+                {% else %}
+                <td class="text-primary text-nowrap">
                   {% endif %}
-                    {{ interval.rain.value | round(1) }} {{ interval.rain.units }}
-                  </td>
+                  {{ interval.rain.value | round(1) }} {{ interval.rain.units }}
+                </td>
 
-                  <td class="text-danger text-nowrap">
-                    {{interval.temp.value | round(1) }}
-                    {% if interval.temp.units == "celsius" %}
-                      &deg;C
-                    {% elif interval.temp.units == "farenheit" %}
-                      &deg;F
-                    {% else %}
-                      forecast.max_temp.units
-                    {% endif %}
-                  </td>
+                <td class="text-danger text-nowrap">
+                  {{interval.temp.value | round(1) }}
+                  {% if interval.temp.units == "celsius" %}
+                  &deg;C
+                  {% elif interval.temp.units == "farenheit" %}
+                  &deg;F
+                  {% else %}
+                  forecast.max_temp.units
+                  {% endif %}
+                </td>
 
-                  <td class="text-nowrap">
-                    {{ interval.wind_speed.value }} {{ interval.wind_speed.units }} {{ interval.wind_from_direction }}
-                  </td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
+                <td class="text-nowrap">
+                  {{ interval.wind_speed.value }} {{ interval.wind_speed.units }} {{ interval.wind_from_direction }}
+                </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
       </div>
     </div>
   </div>
+</div>
 {% endfor %}


### PR DESCRIPTION
Fixes a bug that was causing daily detailed modal windows not to launch because
IDs were not recognised. The bug was caused by the parenthesis in the name
'Lower Cove (Mournes)'. Fixed by removing parenthesis from name string in
forecast table template.